### PR TITLE
[ARM-262] Add initial package manifest for forked iCarousel

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "iCarousel",
+    defaultLocalization: LanguageTag("en"),
+    platforms: [.iOS(.v14), .macOS(.v10_15)],
+    products: [
+        .library(name: "iCarousel", targets: ["iCarousel"]),
+    ],
+    targets: [
+        .target(
+            name: "iCarousel",
+            dependencies: [],
+            path: "iCarousel",
+            exclude: [
+                "Info.plist"
+            ],
+            publicHeadersPath: "iCarousel"
+        ),
+    ]
+)


### PR DESCRIPTION
As a part of https://noomhq.atlassian.net/browse/ARM-262, we forked https://github.com/nicklockwood/iCarousel into our own repo. This PR adds a `Package.swift` package manifest with just the library (ignoring the test target for now).